### PR TITLE
Create basic authentication functionality on the front end

### DIFF
--- a/assets/scripts/auth/api.js
+++ b/assets/scripts/auth/api.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const app = require('../app');
+
+const signUp = (data) => {
+  return $.ajax({
+    url: app.host + '/sign-up',
+    method: 'POST',
+    data: data,
+  });
+};
+
+const signIn = (data, textStatus, jqXHR, signUpData) => {
+  return $.ajax({
+    url: app.host + '/sign-in',
+    method: 'POST',
+    data: signUpData ? signUpData : data,
+  });
+};
+
+const signOut = () => {
+  return $.ajax({
+    url: app.host + '/sign-out/' + app.user.id,
+    method: 'DELETE',
+    headers: {
+      Authorization: 'Token token=' + app.user.token,
+    },
+  });
+};
+
+const changePassword = (data) => {
+  return $.ajax({
+    url: app.host + '/change-password/' + app.user.id,
+    method: 'PATCH',
+    headers: {
+      Authorization: 'Token token=' + app.user.token,
+    },
+    data: data,
+  });
+};
+
+module.exports = {
+  signUp,
+  signIn,
+  signOut,
+  changePassword,
+};

--- a/assets/scripts/auth/api.js
+++ b/assets/scripts/auth/api.js
@@ -20,7 +20,7 @@ const signIn = (data, textStatus, jqXHR, signUpData) => {
 
 const signOut = () => {
   return $.ajax({
-    url: app.host + '/sign-out/' + app.user.id,
+    url: app.host + '/sign-out/' + app.user._id,
     method: 'DELETE',
     headers: {
       Authorization: 'Token token=' + app.user.token,
@@ -30,7 +30,7 @@ const signOut = () => {
 
 const changePassword = (data) => {
   return $.ajax({
-    url: app.host + '/change-password/' + app.user.id,
+    url: app.host + '/change-password/' + app.user._id,
     method: 'PATCH',
     headers: {
       Authorization: 'Token token=' + app.user.token,

--- a/assets/scripts/auth/events.js
+++ b/assets/scripts/auth/events.js
@@ -10,7 +10,7 @@ const onSignUp = (event) => {
   api.signUp(signUpData)
     .done(function (data, textStatus, jqXHR) {
       api.signIn(data, textStatus, jqXHR, signUpData)
-        .done(ui.success)
+        .done(ui.signInSuccess)
         .fail(ui.failure);
     })
     .fail(ui.failure);
@@ -20,7 +20,7 @@ const onSignIn = (event) => {
   event.preventDefault();
   let data = getFormFields(event.target);
   api.signIn(data)
-    .done(ui.success)
+    .done(ui.signInSuccess)
     .fail(ui.failure);
 };
 

--- a/assets/scripts/auth/events.js
+++ b/assets/scripts/auth/events.js
@@ -40,10 +40,10 @@ const onChangePassword = (event) => {
 };
 
 const addHandlers = () => {
-  $(document).on('submit', '#sign-up', onSignUp);
-  $(document).on('submit', '#sign-in', onSignIn);
-  $(document).on('click', '#sign-out', onSignOut);
-  $(document).on('submit', '#change-password', onChangePassword);
+  $(document.body).on('submit', '#sign-up', onSignUp);
+  $(document.body).on('submit', '#sign-in', onSignIn);
+  $(document.body).on('click', '#sign-out', onSignOut);
+  $(document.body).on('submit', '#change-password', onChangePassword);
 };
 
 module.exports = {

--- a/assets/scripts/auth/events.js
+++ b/assets/scripts/auth/events.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const getFormFields = require('../../../lib/get-form-fields');
+const api = require('./api');
+const ui = require('./ui');
+
+const onSignUp = (event) => {
+  event.preventDefault();
+  let signUpData = getFormFields(event.target);
+  api.signUp(signUpData)
+    .done(function (data, textStatus, jqXHR) {
+      api.signIn(data, textStatus, jqXHR, signUpData)
+        .done(ui.success)
+        .fail(ui.failure);
+    })
+    .fail(ui.failure);
+};
+
+const onSignIn = (event) => {
+  event.preventDefault();
+  let data = getFormFields(event.target);
+  api.signIn(data)
+    .done(ui.success)
+    .fail(ui.failure);
+};
+
+const onSignOut = (event) => {
+  event.preventDefault();
+  api.signOut()
+    .done(ui.success)
+    .fail(ui.failure);
+};
+
+const onChangePassword = (event) => {
+  event.preventDefault();
+  let data = getFormFields(event.target);
+  api.changePassword(data)
+    .done(ui.success)
+    .fail(ui.failure);
+};
+
+const addHandlers = () => {
+  $(document).on('submit', '#sign-up', onSignUp);
+  $(document).on('submit', '#sign-in', onSignIn);
+  $(document).on('click', '#sign-out', onSignOut);
+  $(document).on('submit', '#change-password', onChangePassword);
+};
+
+module.exports = {
+  addHandlers,
+};

--- a/assets/scripts/auth/events.js
+++ b/assets/scripts/auth/events.js
@@ -40,10 +40,10 @@ const onChangePassword = (event) => {
 };
 
 const addHandlers = () => {
-  $(document.body).on('submit', '#sign-up', onSignUp);
-  $(document.body).on('submit', '#sign-in', onSignIn);
-  $(document.body).on('click', '#sign-out', onSignOut);
-  $(document.body).on('submit', '#change-password', onChangePassword);
+  $('.auth').on('submit', '#sign-up', onSignUp);
+  $('.auth').on('submit', '#sign-in', onSignIn);
+  $('.auth').on('click', '#sign-out', onSignOut);
+  $('.auth').on('submit', '#change-password', onChangePassword);
 };
 
 module.exports = {

--- a/assets/scripts/auth/ui.js
+++ b/assets/scripts/auth/ui.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const app = require('../app');
+
 const success = (data) => {
   console.log(data);
 };
@@ -8,7 +10,14 @@ const failure = (error) => {
   console.error(error);
 };
 
+const signInSuccess = (data) => {
+  console.log('signed in!');
+  app.user = data.user;
+  success(data);
+};
+
 module.exports = {
   success,
   failure,
+  signInSuccess,
 };

--- a/assets/scripts/auth/ui.js
+++ b/assets/scripts/auth/ui.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const success = (data) => {
+  console.log(data);
+};
+
+const failure = (error) => {
+  console.error(error);
+};
+
+module.exports = {
+  success,
+  failure,
+};

--- a/assets/scripts/index.js
+++ b/assets/scripts/index.js
@@ -1,13 +1,14 @@
 'use strict';
 
 const auth = require('./templates/auth/container.handlebars');
-
 const events = require('./templates/events/container.handlebars');
-
 const rsvps = require('./templates/rsvps/container.handlebars');
+
+const authEvents = require('./auth/events.js');
 
 $(() => {
   $('.auth').html(auth);
   $('.events').html(events);
   $('.rsvps').html(rsvps);
+  authEvents.addHandlers();
 });

--- a/assets/scripts/templates/auth/container.handlebars
+++ b/assets/scripts/templates/auth/container.handlebars
@@ -43,3 +43,18 @@
 </div>
 
 <a href="" id="sign-out"><h1>Sign Out</h1></a>
+
+<div class="pwd-form">
+  <h1>Change password</h1>
+  <form id="change-password" class="change-password">
+    <div>
+      <label for="passwords[old]">Current password</label>
+      <input name="passwords[old]" id="passwords[old]" type="password" placeholder="Current password">
+    </div>
+    <div>
+      <label for="passwords[new]">New password</label>
+      <input name="passwords[new]" id="passwords[new]" type="password" placeholder="New password">
+    </div>
+    <button type="submit">Change Password</button>
+  </form>
+</div>

--- a/assets/scripts/templates/auth/container.handlebars
+++ b/assets/scripts/templates/auth/container.handlebars
@@ -24,3 +24,22 @@
 
   <p>Have an account? <a class="sign-in" role="button" href="">Sign in.</a></p>
 </div>
+
+<div class="wrapper">
+  <h1>Sign In</h1>
+  <form id="sign-in">
+    <div>
+      <label for="credentials[email]">Email</label>
+      <input name="credentials[email]" id="credentials[email]" type="email" placeholder="Email" required>
+    </div>
+    <div>
+      <label for="credentials[password]">Password</label>
+      <input name="credentials[password]" id="credentials[password]" type="password" placeholder="Password" required>
+    </div>
+    <p><button type="submit">Sign In</button></p>
+  </form>
+
+  <p>No account? <a class="sign-up" role="button" href="">Sign up.</a></p>
+</div>
+
+<a href="" id="sign-out"><h1>Sign Out</h1></a>

--- a/assets/scripts/templates/auth/container.handlebars
+++ b/assets/scripts/templates/auth/container.handlebars
@@ -1,1 +1,26 @@
 <h1>Auth</h1>
+
+<div class="wrapper">
+  <h1>Sign Up</h1>
+  <form id="sign-up">
+    <div>
+      <label for="credentials[email]">Email</label>
+      <input name="credentials[email]" id="credentials[email]" type="email" placeholder="Email" required>
+    </div>
+    <div>
+      <label for="credentials[username]">Username</label>
+      <input name="credentials[username]" id="credentials[username]" type="username" placeholder="Username" required>
+    </div>
+    <div>
+      <label for="credentials[password]">Password</label>
+      <input name="credentials[password]" id="credentials[password]" type="password" placeholder="Password" required>
+    </div>
+    <div>
+      <label for="credentials[password_confirmation]">Confirm password</label>
+      <input name="credentials[password_confirmation]" id="credentials[password_confirmation]" type="password" placeholder="Confirm password" required>
+    </div>
+    <p><button type="submit">Sign Up</button></p>
+  </form>
+
+  <p>Have an account? <a class="sign-in" role="button" href="">Sign in.</a></p>
+</div>


### PR DESCRIPTION
Create basic authentication functionality on the front end. A couple of notes:
1. The sign up, sign in, and change password forms, plus the sign out link, are in a single Handlebars template (`assets/scripts/templates/auth/container.handlebars`) for now.
2. The `onSignUp` method in `assets/scripts/auth/events.js` signs up. If sign up is successful, it automatically signs in. It does this by holding on to the sign up data (which has the email and password), and passing that data along to the log in function if sign up is successful. If either sign up OR sign in fail here, then we get an error.
3. In `assets/scripts/auth/ui.js`, I have the "generic" success/failure functions that are just `console.log` and `console.error`. I also have one "custom" success function for signing in that stores the user data to `app.user`. Other than that, still lots of UI work to do. 😃 

No need to review this tonight! We can talk about it tomorrow; just wanted to get the code set up like we talked about.
