### PR TITLE
Make start and end time options functional

### DIFF
--- a/assets/scripts/events/events.js
+++ b/assets/scripts/events/events.js
@@ -38,9 +38,15 @@ const createEvent = function (event) {
   event.preventDefault();
   let data = getFormFields(event.target);
   console.log(data);
-    api.createNewEvent(data)
-      .done(ui.createEventsSuccess)
-      .fail(ui.failure);
+  // this is string interpolation using "template literals"
+  // same as:
+  // data.event.data + 'T' + data.event.startTime + ':00'
+  data.event.startTime = `${data.event.date}T${data.event.startTime}:00`;
+  data.event.endTime = `${data.event.date}T${data.event.endTime}:00`;
+  console.log('improved', data);
+  api.createNewEvent(data)
+    .done(ui.createEventsSuccess)
+    .fail(ui.failure);
 };
 
 
@@ -57,6 +63,8 @@ const getEditForm = function (event) {
 const updateEvent = function (event) {
   event.preventDefault();
   let data = getFormFields(event.target);
+  data.event.startTime = `${data.event.date}T${data.event.startTime}:00`;
+  data.event.endTime = `${data.event.date}T${data.event.endTime}:00`;
     api.updateEvent(data)
       .done(ui.singleEventSuccess)
       .fail(ui.failure);

--- a/assets/scripts/events/ui.js
+++ b/assets/scripts/events/ui.js
@@ -15,12 +15,55 @@ const allEventsSuccess = (data) => {
    $(".all-events").html(showAllEventsTemplate(allEvents));
 };
 
+// convert from 24 hour clock to 12 hour clock
+const formatTime = (time) => {
+  // time comes in as '17:30'
+  // using .substring to get the first two digits (the hour)
+  // if it's less than 12, add " AM" to make the time "08:30 AM"
+  if (time.substring(0,2) < 12) {
+    return time += ' AM';
+  } else {
+    // get the hour
+    let oldHour = time.substring(0,2);
+
+    // subtract 12 from the hour so '17' becomes '5'
+    let newHour = parseInt(oldHour, 10) - 12;
+    console.log(newHour);
+
+    // replace the 24-hour version of the hour with the 12-hour version
+    time = time.replace(oldHour, newHour); 
+
+    // add a 0 to the beginning so '5' becomes '05'
+    if (newHour < 10) {
+      time = `0${time}`;
+    }
+    console.log('PM time is', time);
+    // add " PM" to make the time "05:30 PM"
+    return time += ' PM';
+  }
+};
+
 // for showing a single event
 const singleEventSuccess = (data) => {
- console.log('single event success data is', data);
-   let event = data.event;
-//   console.log(lists);
-   $(".single-event").html(showSingleEventTemplate(event));
+  console.log('single event success data is', data);
+
+  // date and time both come in from API as '2016-10-20T12:30:00'
+  // .split('T') turns it into ['2016-10-20', '12:30:00']
+  // taking the first element of that array gets us a nicely formatted data
+  data.event.date = data.event.date.split('T')[0];
+
+  // taking the second element gets us the time as '12:30:00'
+  // .substring(0, 5) will start at the first character of that string
+  // and return 5 total characters: '12:30' (four digits plus the colon)
+  data.event.startTime = data.event.startTime.split('T')[1].substring(0, 5);
+  data.event.endTime = data.event.endTime.split('T')[1].substring(0, 5);
+
+  // using the formatTime function above to make the time pretty
+  data.event.startTime = formatTime(data.event.startTime);
+  data.event.endTime = formatTime(data.event.endTime);
+  let event = data.event;
+  console.log('formatted event data', event);
+  $(".single-event").html(showSingleEventTemplate(event));
 };
 
 // for getting my events
@@ -33,15 +76,18 @@ const myEventsSuccess = (data) => {
 };
 
 const createEventSuccess = () => {
-console.log('event created successfully!!');
+  console.log('event created successfully!!');
 };
 
 // show edit form
 const editFormSuccess = (data) => {
- console.log('single event success data is', data);
-   let event = data.event;
-//   console.log(lists);
-   $(".single-event").html(showEditFormTemplate(event));
+  console.log('single event success data is', data);
+  data.event.date = data.event.date.split('T')[0];
+  data.event.startTime = data.event.startTime.split('T')[1].substring(0, 5);
+  data.event.endTime = data.event.endTime.split('T')[1].substring(0, 5);
+  console.log(data);
+  let event = data.event;
+  $(".single-event").html(showEditFormTemplate(event));
 };
 
 const deleteEventSuccess = () => {

--- a/assets/scripts/templates/events/container.handlebars
+++ b/assets/scripts/templates/events/container.handlebars
@@ -21,14 +21,14 @@
       <label for="event[date]">Date</label>
       <input name="event[date]" id="event[date]" type="date" required>
     </div>
-    <!-- <div>
+    <div>
       <label for="event[startTime]">Starts</label>
       <input name="event[startTime]" id="event[startTime]" type="time">
     </div>
     <div>
       <label for="event[endTime]">Ends</label>
       <input name="event[endTime]" id="event[endTime]" type="time">
-    </div> -->
+    </div>
     <div>
       <label for="event[description]">Description</label>
       <input name="event[description]" id="event[description]" type="text">


### PR DESCRIPTION
Add functionality for converting the date and time formats between what Mongo expects and what humans like to see.

Use this functionality when sending a new event or an updated event to the server.

Also use it when getting data back from the server, so we can display a single event better.

Code is heavily commented and mostly uses JavaScript string manipulation & template literals to format stuff.
