### PR TITLE
Add functionality to display single RSVP

### DIFF
--- a/assets/scripts/rsvps/events.js
+++ b/assets/scripts/rsvps/events.js
@@ -27,10 +27,18 @@ const getMyRsvps = () => {
       .fail(ui.failure);
 };
 
+const onShowRsvp = (event) => {
+  event.preventDefault();
+  let rsvpId = $(event.target).attr('data-id');
+  api.getOneRsvp(rsvpId)
+    .done(ui.singleRsvpSuccess)
+    .fail(ui.failure);
+};
+
 const addHandlers = () => {
   $('.events').on('submit','#create-rsvp', onCreateRsvp);
   $('.rsvps').on('click', '#get-my-rsvps', getMyRsvps);
-
+  $('.rsvps').on('click', '.show-rsvp', onShowRsvp);
 };
 
 module.exports = {

--- a/assets/scripts/rsvps/ui.js
+++ b/assets/scripts/rsvps/ui.js
@@ -2,7 +2,8 @@
 
  // const app = require('../app');
 
- const myRsvpsTemplate = require('../templates/rsvps/my-rsvps.handlebars');
+const myRsvpsTemplate = require('../templates/rsvps/my-rsvps.handlebars');
+const singleRsvpTemplate = require('../templates/rsvps/single-rsvp.handlebars');
 
 const createRsvpSuccess = (data) => {
   console.log("inside createRsvpSuccess", data);
@@ -13,9 +14,15 @@ const myRsvpsSuccess = (data) => {
   $('.my-rsvps').html(myRsvpsTemplate(data));
 };
 
+const singleRsvpSuccess = (data) => {
+  console.log('the single RSVP data is', data);
+  let rsvp = data.rsvp;
+  $('.single-rsvp').html(singleRsvpTemplate(rsvp));
+};
 
 
 module.exports = {
   createRsvpSuccess,
   myRsvpsSuccess,
+  singleRsvpSuccess,
 };

--- a/assets/scripts/templates/events/events-partial.handlebars
+++ b/assets/scripts/templates/events/events-partial.handlebars
@@ -1,6 +1,6 @@
 {{#each events}}
 
-<p><a href="" class='show-event' data-id='{{id}}'>
+<p><a href="" class='event-box show-event' data-id='{{id}}'>
 {{title}}
 {{date}}
 </a></p>

--- a/assets/scripts/templates/rsvps/container.handlebars
+++ b/assets/scripts/templates/rsvps/container.handlebars
@@ -1,5 +1,6 @@
 <h1>Rsvp</h1>
 
+<div class="single-rsvp"></div>
 <div class="my-rsvps"></div>
 
 <button id="get-my-rsvps">Get My Rsvps</button>

--- a/assets/scripts/templates/rsvps/rsvps-partial.handlebars
+++ b/assets/scripts/templates/rsvps/rsvps-partial.handlebars
@@ -1,6 +1,6 @@
 {{#each rsvps}}
 
-<p><a href="" class='show-event' data-id='{{id}}'>
+<p><a href="" class='event-box show-rsvp' data-id='{{id}}'>
 {{title}}
 {{date}}
 </a></p>

--- a/assets/scripts/templates/rsvps/single-rsvp.handlebars
+++ b/assets/scripts/templates/rsvps/single-rsvp.handlebars
@@ -1,0 +1,16 @@
+<a href="" class="update-rsvp" data-id='{{id}}'>Edit</a>
+
+<ul>
+<li>Event Title: {{title}}</li>
+<li>Event Date: {{date}}</li>
+<li>Location: {{location}}</li>
+<li>Description: {{description}}</li>
+<li>Starts: {{startTime}}</li>
+<li>Ends: {{endTime}}</li>
+</ul>
+
+{{#each questions}}
+<p>{{text}}</p>
+<p>{{options}}</p>
+
+{{/each}}


### PR DESCRIPTION
Add new classes to show-event and show-rsvp links:
- one class for CSS that is the same for both kinds of links
- one class for JS that is different for events vs. rsvps

Add event handler that shows a single RSVP when you click on that RSVP's link.
Add div in rsvp container to hold that single RSVP (div.single-rsvp)

Add Handlebars template to display a single RSVP (including printing out the selected answer(s)).
