### PR TITLE
Add edit RSVP functionality

### DIFF
--- a/assets/scripts/events/events.js
+++ b/assets/scripts/events/events.js
@@ -98,7 +98,7 @@ const addHandlers = () => {
  $('.events').on('click','.update-event', getEditForm);
  $('.events').on('submit','#update-event-form', updateEvent);
  $('.events').on('click','.delete-event', deleteEvent);
-
+ $('.rsvps').on('click','.update-rsvp', showSingleEvent);
  };
 
 module.exports = {

--- a/assets/scripts/events/ui.js
+++ b/assets/scripts/events/ui.js
@@ -88,6 +88,7 @@ const singleEventSuccess = (data) => {
       $(".single-event").html(showSingleEventTemplate(event));
     }
     else {
+    // we should think about what the main div is that we're filling up with content
       $(".single-event").html(showRsvpViewTemplate(event));
     }
 };

--- a/assets/scripts/templates/rsvps/single-rsvp.handlebars
+++ b/assets/scripts/templates/rsvps/single-rsvp.handlebars
@@ -1,4 +1,4 @@
-<a href="" class="update-rsvp" data-id='{{id}}'>Edit</a>
+<a href="" class="update-rsvp" data-id='{{_event}}'>Edit</a>
 
 <ul>
 <li>Event Title: {{title}}</li>


### PR DESCRIPTION
Clicking on the "edit" link in the single RSVP view calls a function in events/events.js.
That function displays the "single Event view," which is either the RSVP form or the event view.

If you don't own the event, you'll see the RSVP form.

Submitting that form updates your RSVP using the rsvps#createorupdate method in the RSVP controller.
