### PR TITLE
Flexible answers

### DIFF
--- a/assets/scripts/events/ui.js
+++ b/assets/scripts/events/ui.js
@@ -33,29 +33,42 @@ const singleEventSuccess = (data) => {
   let responses = {};
   // loop through the event questions to find each question
   data.event.questions.forEach((question) => {
-    //set up an empty "answers" object
+    // for each question, add the question text as a property key on responses
+    // the value of that property is an empty array, which will hold the answer objects
     responses[question.text] = [];
-    // let response = {
-    //   questionText: question.text,
-    //   questionOptions: [],
-    // };
 
+    // for each option, set up an object that looks like: { "Yes": 0 }
+    // push that option into the array we set up above
     question.options.forEach((option) => {
       let answer = {};
       answer[option] = 0;
       responses[question.text].push(answer);
     });
 
-    // responses.push(response);
+    // the end result looks like:
+
+    // responses = {
+    //   "Are you coming?": [
+    //     { "Yes": 0 },
+    //     { "No": 0 },
+    //     { "Maybe": 0 },
+    //   ],
+    // };
 
   });
 
   console.log('responses for this event', responses);
 
+  // loop through each of the rsvps
   data.event.rsvps.forEach((rsvp) => {
+    // loop through each question/answer in the rsvp
     rsvp.questions.forEach((question) => {
-      // responses[question.text][question.options] = responses[question.text][question.options] + 1;
+      // find the appropriate question in the responses object and go through all of the possible answers
       responses[question.text].forEach((option) => {
+        // if there's a match between the response in the RSVP and the answer option, increment the count
+        // so if the rsvp is "Yes" for "Are you coming?"
+        // then change tha answer option inside of the responses object for that question
+        // to { "Yes": 1 }
         if (option.hasOwnProperty(question.options)) {
           option[question.options] = option[question.options] + 1;
         }
@@ -87,6 +100,7 @@ const singleEventSuccess = (data) => {
   // event.no = no;
   // event.maybe = maybe;
 
+  // add the responses object to the event data so we can use it in handlebars
   event.responses = responses;
 
   console.log('formatted event data', event);

--- a/assets/scripts/events/ui.js
+++ b/assets/scripts/events/ui.js
@@ -29,29 +29,65 @@ const singleEventSuccess = (data) => {
   if (data.event.endTime) {
     data.event.endTime = formatDateTime.convertClock(data.event.endTime);
   }
-  // we need to get the counts of rsvps. loop through each rsvp to see if yes, no, or maybe
-  let yes = 0;
-  let no = 0;
-  let maybe = 0;
+
+  let responses = {};
+  // loop through the event questions to find each question
+  data.event.questions.forEach((question) => {
+    //set up an empty "answers" object
+    responses[question.text] = [];
+    // let response = {
+    //   questionText: question.text,
+    //   questionOptions: [],
+    // };
+
+    question.options.forEach((option) => {
+      let answer = {};
+      answer[option] = 0;
+      responses[question.text].push(answer);
+    });
+
+    // responses.push(response);
+
+  });
+
+  console.log('responses for this event', responses);
 
   data.event.rsvps.forEach((rsvp) => {
-    if(rsvp.questions[0].options === 'Yes') {
-      yes++;
-    }
-    else if(rsvp.questions[0].options === 'No') {
-      no++;
-    }
-    else if(rsvp.questions[0].options === 'Maybe') {
-      maybe++;
-    }
-  //  console.log('rsvp is', rsvp.questions[0].options);
+    rsvp.questions.forEach((question) => {
+      // responses[question.text][question.options] = responses[question.text][question.options] + 1;
+      responses[question.text].forEach((option) => {
+        if (option.hasOwnProperty(question.options)) {
+          option[question.options] = option[question.options] + 1;
+        }
+      });
+    });
   });
-    console.log("yes is", yes, "no is", no, "maybe is", maybe);
+  console.log('responses for this event', responses);
+  // we need to get the counts of rsvps. loop through each rsvp to see if yes, no, or maybe
+  // let yes = 0;
+  // let no = 0;
+  // let maybe = 0;
+
+  // data.event.rsvps.forEach((rsvp) => {
+  //   if(rsvp.questions[0].options === 'Yes') {
+  //     yes++;
+  //   }
+  //   else if(rsvp.questions[0].options === 'No') {
+  //     no++;
+  //   }
+  //   else if(rsvp.questions[0].options === 'Maybe') {
+  //     maybe++;
+  //   }
+  // //  console.log('rsvp is', rsvp.questions[0].options);
+  // });
+  //   console.log("yes is", yes, "no is", no, "maybe is", maybe);
 
   let event = data.event;
-  event.yes = yes;
-  event.no = no;
-  event.maybe = maybe;
+  // event.yes = yes;
+  // event.no = no;
+  // event.maybe = maybe;
+
+  event.responses = responses;
 
   console.log('formatted event data', event);
   // if the event owner id and the user id match show single event view otherwise

--- a/assets/scripts/templates/events/single-event.handlebars
+++ b/assets/scripts/templates/events/single-event.handlebars
@@ -10,7 +10,7 @@
 <li>Ends: {{endTime}}</li>
 </ul>
 
-<h2>Response keys</h2>
+<h2>Attendees</h2>
 {{#each responses}}
 <p>{{@key}}</p>
   {{#each this}}

--- a/assets/scripts/templates/events/single-event.handlebars
+++ b/assets/scripts/templates/events/single-event.handlebars
@@ -10,8 +10,12 @@
 <li>Ends: {{endTime}}</li>
 </ul>
 
-<h2> Attendees </h2>
-
-<p>People attending: {{yes}}</p>
-<p>People declined: {{no}}</p>
-<p>People undecided: {{maybe}}</p>
+<h2>Response keys</h2>
+{{#each responses}}
+<p>{{@key}}</p>
+  {{#each this}}
+    {{#each this}}
+      <p>{{@key}}: {{this}}</p>
+    {{/each}}
+  {{/each}}
+{{/each}}

--- a/assets/scripts/templates/rsvps/rsvp-view.handlebars
+++ b/assets/scripts/templates/rsvps/rsvp-view.handlebars
@@ -10,11 +10,15 @@
 <li>Ends: {{endTime}}</li>
 </ul>
 
-<h2> Attendees </h2>
-
-<p>People attending: {{yes}}</p>
-<p>People declined: {{no}}</p>
-<p>People undecided: {{maybe}}</p>
+<h2>Response keys</h2>
+{{#each responses}}
+<p>{{@key}}</p>
+  {{#each this}}
+    {{#each this}}
+      <p>{{@key}}: {{this}}</p>
+    {{/each}}
+  {{/each}}
+{{/each}}
 
 <form id="create-rsvp">
 <input type="hidden" id="rsvp[_event]" name="rsvp[_event]" value="{{id}}">


### PR DESCRIPTION
Instead of hardcoding in "yes," "no," and "maybe," in the single event/single RSVP view, leave our options open to automatically detect questions & answers and count up responses. This lets us use multiple questions (if we get to the point where we're editing the form to allow users to create multiple questions for their events).
